### PR TITLE
chore: bump Spring Boot to 3.5.5

### DIFF
--- a/gs-producing-web-service/pom.xml
+++ b/gs-producing-web-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.5.5</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary
- bump Spring Boot parent to v3.5.5

## Testing
- `cd gs-producing-web-service && mvn -q test && cd ..` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c750123d68832094539f3534b134d7