### PR TITLE
chore: upgrade to java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Spring
-Spring 
+Spring
+
+This sample now targets **Java 21**.

--- a/gs-producing-web-service/pom.xml
+++ b/gs-producing-web-service/pom.xml
@@ -17,7 +17,7 @@
     <description>Hello World Spring Boot application</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- update Maven build to target Java 21
- document Java 21 requirement in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c750ab3c508320ab2e54c710132e5f